### PR TITLE
Change className to class

### DIFF
--- a/src/base.tsx
+++ b/src/base.tsx
@@ -166,7 +166,7 @@ const createStyled: CreateStyledFunction = (tag: any, options?: StyledOptions) =
         <Dynamic
           component={finalTag}
           {...newProps}
-          className={
+          class={
             props.class ? `${className()} ${props.class}` : className()
           }
         />


### PR DESCRIPTION
This will fix extending component styles when there's a class being passed through props and styles class is not being applied

Because solid uses class and not className